### PR TITLE
Consider enabling tests

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,9 @@ Build-Depends:
  debhelper-compat (= 12),
  dh-exec,
  dh-python,
+ flake8 <!nocheck>,
  pandoc,
+ python3-nose <!nocheck>,
  python3-pkg-resources,
  python3-setuptools,
  zip

--- a/debian/patches/disable-autoupdate-mechanism.patch
+++ b/debian/patches/disable-autoupdate-mechanism.patch
@@ -15,9 +15,29 @@ Last-Update: 2018-03-16
  youtube_dl/options.py  | 2 +-
  2 files changed, 7 insertions(+), 2 deletions(-)
 
+--- a/README.md
++++ a/README.md
+@@ -53,9 +53,6 @@
+ # OPTIONS
+     -h, --help                       Print this help text and exit
+     --version                        Print program version and exit
+-    -U, --update                     Update this program to latest version. Make
+-                                     sure that you have sufficient permissions
+-                                     (run with sudo if needed)
+     -i, --ignore-errors              Continue on download errors, for example to
+                                      skip unavailable videos in a playlist
+     --abort-on-error                 Abort downloading of further videos (in the
 --- a/youtube_dl/__init__.py
 +++ b/youtube_dl/__init__.py
-@@ -441,7 +441,12 @@
+@@ -36,7 +36,6 @@
+     write_string,
+     render_table,
+ )
+-from .update import update_self
+ from .downloader import (
+     FileDownloader,
+ )
+@@ -441,7 +440,12 @@
      with YoutubeDL(ydl_opts) as ydl:
          # Update version
          if opts.update_self:

--- a/debian/patches/disable_more_online_tests.patch
+++ b/debian/patches/disable_more_online_tests.patch
@@ -1,0 +1,21 @@
+Description: Disable remaining tests that require internet.
+Author: Unit 193 <unit193@ubuntu.com>
+
+---
+ Makefile |    5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+--- a/Makefile
++++ b/Makefile
+@@ -49,7 +49,10 @@
+ 		--exclude test_subtitles.py \
+ 		--exclude test_write_annotations.py \
+ 		--exclude test_youtube_lists.py \
+-		--exclude test_youtube_signature.py
++		--exclude test_youtube_signature.py \
++		--exclude test_downloader_http.py \
++		--exclude test_InfoExtractor.py \
++		--exclude test_http.py
+ 
+ tar: youtube-dl.tar.gz
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 skip_support_file_installation.patch
 disable-autoupdate-mechanism.patch
+disable_more_online_tests.patch

--- a/debian/rules
+++ b/debian/rules
@@ -9,11 +9,9 @@ export PATH := $(CURDIR)/debian/utils:$(PATH)
 
 override_dh_auto_configure:
 	PREFIX=/usr SYSCONFDIR=/etc make
-	mv Makefile Makefile.inactive
 	rm youtube-dl
 
 override_dh_clean:
-	test -f Makefile || mv Makefile.inactive Makefile
 	make clean
 	dh_clean
 

--- a/debian/rules
+++ b/debian/rules
@@ -16,3 +16,6 @@ override_dh_clean:
 	dh_clean
 
 override_dh_auto_test:
+ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
+	make offlinetest PYTHON=python3
+endif


### PR DESCRIPTION
If one simply adds a couple changes, one can actually run the tests of youtube-dl.  Note: I tested this with a newer version of ytdl, not technically the version I'm making a pull to.