### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Build-Depends-Indep:
 Rules-Requires-Root: no
 Standards-Version: 4.5.0
 Vcs-Browser: https://github.com/rbrito/pkg-youtube-dl
-Vcs-Git: https://github.com/rbrito/pkg-youtube-dl
+Vcs-Git: https://github.com/rbrito/pkg-youtube-dl.git
 Homepage: https://ytdl-org.github.io/youtube-dl/
 
 Package: youtube-dl

--- a/debian/copyright
+++ b/debian/copyright
@@ -35,7 +35,7 @@ License: public-domain
 
 Files: debian/*
 Copyright: © 2006, Robert S. Edmonds <edmonds@debian.org>.
-	   © 2009-2019, Rogério Brito <rbrito@ime.usp.br>.
+           © 2009-2019, Rogério Brito <rbrito@ime.usp.br>.
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/ytdl-org/youtube-dl/issues
+Bug-Submit: https://github.com/ytdl-org/youtube-dl/issues/new
+Repository: https://github.com/ytdl-org/youtube-dl.git
+Repository-Browse: https://github.com/ytdl-org/youtube-dl


### PR DESCRIPTION
Fix some issues reported by lintian
* debian/copyright: use spaces rather than tabs to start continuation lines. ([tab-in-license-text](https://lintian.debian.org/tags/tab-in-license-text.html))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))
* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/youtube-dl/8557d7ea-82cf-4dd9-9f15-a0ff4579c252.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/8557d7ea-82cf-4dd9-9f15-a0ff4579c252/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/8557d7ea-82cf-4dd9-9f15-a0ff4579c252/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/8557d7ea-82cf-4dd9-9f15-a0ff4579c252/diffoscope)).
